### PR TITLE
Column Selector

### DIFF
--- a/administrator/components/com_j2store/views/products/tmpl/default_items.php
+++ b/administrator/components/com_j2store/views/products/tmpl/default_items.php
@@ -38,7 +38,6 @@ $wa->useScript('table.columns')
     </caption>
 	<thead>
 		<tr>
-			<td class="w-1 text-center d-none"><?php //echo Text::_('J2STORE_NUM');?></td>
 			<td class="w-1 text-center"><input type="checkbox" name="checkall-toggle" value="" title="<?php echo Text::_('JGLOBAL_CHECK_ALL'); ?>" onclick="Joomla.checkAll(this)" /></td>
 			<th scope="col" class="text-center d-none d-md-table-cell">
 				<?php echo HTMLHelper::_('grid.sort', 'J2STORE_PRODUCT_ID', 'j2store_product_id', $this->state->filter_order_Dir, $this->state->filter_order); ?>
@@ -65,7 +64,6 @@ $wa->useScript('table.columns')
                 $r++;
             ?>
             <tr class="row<?php echo $r;?>">
-                <td class="d-none"><?php //echo $this->pagination->getRowOffset( $i ); ?></td>
                 <td><?php echo $checked; ?></td>
                 <td class="text-center d-none d-md-table-cell"><?php echo $item->j2store_product_id;?></td>
                 <td><?php


### PR DESCRIPTION
The column selector should not include the checkbox as that is always required and should not be able to be removed.

The script assumes that the first column is the checkbox but in this view there was an extra empty column.

This PR removes the extra column. I assume it is safe to do that as the contents of the column were commented out.

### Before
![image](https://github.com/user-attachments/assets/e8dce958-6c54-4b05-8182-3aa595b20c23)

### After
![image](https://github.com/user-attachments/assets/9507e8ba-e61d-493a-ae9b-c565146a2265)
