### PR TITLE
Support Atum Admin Styles

### DIFF
--- a/media/j2store/css/J4/j2store_admin.css
+++ b/media/j2store/css/J4/j2store_admin.css
@@ -819,7 +819,7 @@ div.j2store-tab div.j2store-tab-content:not(.active){
     border-left:3px solid #1B7ECF;
 }
 #j2store-navbar .bg-primary {
-    background-color: #132f53!important;
+    background-color: var(--template-bg-dark-80)!important;
 }
 
 #j2store-navbar .nav-item{
@@ -841,10 +841,10 @@ div.j2store-tab div.j2store-tab-content:not(.active){
     font-size:0.86rem;
 }
 #j2store-navbar .dropdown-item:hover{
-    background-color:#3d618f;
+    background-color: var(--template-bg-dark-60);
 }
 #j2store-navbar .active{
-    background-color:#2e486b;
+    background-color: var(--template-bg-dark-70);
 }
 #j2store-navbar #dropdown{
     position: relative;


### PR DESCRIPTION
Before this PR if you change the admin style hue then j2store header stays blue

With this PR the header inherits the template style.

## Before Default
![image](https://github.com/user-attachments/assets/58cd1596-e2af-47ea-9ec5-935e98df8ac4)

## Before Hue 138
![image](https://github.com/user-attachments/assets/98fac707-a75e-42e7-8a59-a33e3d2c0533)

## After Default
![image](https://github.com/user-attachments/assets/4d28360f-6bf8-4919-b1e7-e370e999cef4)

## After Hue 138
![image](https://github.com/user-attachments/assets/76c2ac49-dfc1-4e00-b48c-240b72fb1d9b)

can be tweaked at a future date - this serves as an example