### PR TITLE
You must specify a non-empty path to clean error

### DIFF
--- a/administrator/components/com_j2store/models/products.php
+++ b/administrator/components/com_j2store/models/products.php
@@ -440,11 +440,11 @@ class J2StoreModelProducts extends F0FModel {
                 // Find the parent path to our subfolder
 
 				$realpath = @realpath($folder.'/'.$subfolder.'/..');
-				// realpath cleans the path of extra / so if folder and subfolder are empty, and the path cannot be
+				// realpath may return false which cannot be used as entry value for Path::clean
 				if ($realpath) {
 					$parent = JPath::clean($realpath);
 				} else {
-					$parent = $realpath;
+					$parent = '';
 				}
 
                 $parent = trim( str_replace(JPath::clean($folder), '', $parent) , '/\\' );

--- a/administrator/components/com_j2store/models/products.php
+++ b/administrator/components/com_j2store/models/products.php
@@ -438,7 +438,15 @@ class J2StoreModelProducts extends F0FModel {
                     exit;
                 }
                 // Find the parent path to our subfolder
-                $parent = JPath::clean( @realpath($folder.'/'.$subfolder.'/..') );
+
+				$realpath = @realpath($folder.'/'.$subfolder.'/..');
+				// realpath cleans the path of extra / so if folder and subfolder are empty, and the path cannot be
+				if ($realpath) {
+					$parent = JPath::clean($realpath);
+				} else {
+					$parent = $realpath;
+				}
+
                 $parent = trim( str_replace(JPath::clean($folder), '', $parent) , '/\\' );
                 $folder = JPath::clean ( $folder . '/' . $subfolder );
 


### PR DESCRIPTION
When using Amazon S3, nothing comes out of products 'getFiles' because of a 'You must specify a non-empty path to clean' error. It happens because realpath returns false. 