### PR TITLE
Fix deprecated notice when the menu for "Products List View" view doesn't have a Meta Description. #60

### DIFF
--- a/components/com_j2store/controllers/products.php
+++ b/components/com_j2store/controllers/products.php
@@ -232,7 +232,7 @@ class J2StoreControllerProducts extends J2StoreControllerProductsBase
 		$uri = JURI::getInstance();
 		$document->setMetaData('og:title', $document->getTitle(),'property');
 		$document->setMetaData('og:site_name', $app->get('sitename'),'property');
-        $document->setMetaData('og:description', strip_tags($document->getDescription()),'property');
+        $document->setMetaData('og:description', strip_tags($document->getDescription() ?? ''),'property');
 		$document->setMetaData('og:url', $uri->toString(),'property');
 		$document->setMetaData('og:type', 'product.group','property');
 


### PR DESCRIPTION
Fix deprecated notice when the menu for "Products List View" view doesn't have a Meta Description. More info: #60