### PR TITLE
Refactoring JFactory() in frontend

### DIFF
--- a/components/com_j2store/controllers/callback.php
+++ b/components/com_j2store/controllers/callback.php
@@ -9,6 +9,7 @@
 # Technical Support:  Forum - http://j2store.org/forum/index.html
 -------------------------------------------------------------------------*/
 
+use Joomla\CMS\Factory;
 
 /** ensure this file is being included by a parent file */
 defined('_JEXEC') or die('Restricted access');
@@ -31,7 +32,7 @@ class J2StoreControllerCallback extends F0FController
 		// Makes sure SiteGround's SuperCache doesn't cache the subscription page
 		J2Store::utilities()->nocache();
 		
-		$app = JFactory::getApplication();
+		$app = Factory::getApplication();
 		$app->setHeader('X-Cache-Control', 'False', true);
 		$method = $app->input->getCmd('method', 'none');
 		$model = $this->getModel('Callback');		

--- a/components/com_j2store/controllers/checkouts.php
+++ b/components/com_j2store/controllers/checkouts.php
@@ -6,6 +6,9 @@
  */
 // No direct access to this file
 defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+
 class J2StoreControllerCheckouts extends F0FController
 {
 
@@ -20,7 +23,7 @@ class J2StoreControllerCheckouts extends F0FController
 
 	protected function onBeforeGenericTask($task)
 	{
-		$format = JFactory::getApplication()->input->getString('format', '');
+		$format = Factory::getApplication()->input->getString('format', '');
 		$forbidden = array('json', 'csv', 'pdf');
 		if(in_array(strtolower($format), $forbidden)) {
 			return false;
@@ -31,7 +34,7 @@ class J2StoreControllerCheckouts extends F0FController
 
 	protected function onBeforeBrowse() {
 
-		$format = JFactory::getApplication()->input->getString('format', '');
+		$format = Factory::getApplication()->input->getString('format', '');
 		$forbidden = array('json', 'csv', 'pdf');
 		if(in_array(strtolower($format), $forbidden)) {
 			return false;
@@ -43,8 +46,8 @@ class J2StoreControllerCheckouts extends F0FController
 	public function display($cachable = false, $urlparams = array(), $tpl=null) {
 
 		$document = F0FPlatform::getInstance()->getDocument();
-		$app = JFactory::getApplication();
-		$user = JFactory::getUser();
+		$app = Factory::getApplication();
+        $user = $app->getIdentity();
 
 		if ($document instanceof JDocument)
 		{
@@ -76,7 +79,7 @@ class J2StoreControllerCheckouts extends F0FController
 
 		$order = F0FModel::getTmpInstance('Orders', 'J2StoreModel')->initOrder()->getOrder();
 		$items = $order->getItems();
-		$session = JFactory::getSession ();
+		$session = $app->getSession ();
 		$is_mobile = $session->get('is_mobile','','j2store');
         $cart_params = array();
         if ($is_mobile){
@@ -119,8 +122,8 @@ class J2StoreControllerCheckouts extends F0FController
 
 
 	function login() {
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
 		$view = $this->getThisView();
 
 		if ($model = $this->getThisModel())
@@ -152,9 +155,9 @@ class J2StoreControllerCheckouts extends F0FController
 
 	function login_validate() {
 
-		$app = JFactory::getApplication();
-		$user = JFactory::getUser();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+        $user = $app->getIdentity();
+		$session = $app->getSession();
 		$params = J2Store::config();
 		$session->set('uaccount', 'login', 'j2store');
 
@@ -190,7 +193,7 @@ class J2StoreControllerCheckouts extends F0FController
 
 		if (!$json) {
 			$session->clear('guest', 'j2store');
-            $user = JFactory::getUser();
+            $user = $app->getIdentity();
 			// Default Addresses
 			$address_info = F0FModel::getTmpInstance('Addresses', 'J2StoreModel')->user_id($user->id)->getFirstItem();
 
@@ -225,8 +228,8 @@ class J2StoreControllerCheckouts extends F0FController
 	}
 
 	function register() {
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
 		$params = J2Store::config();
 
 		$view = $this->getThisView();
@@ -281,7 +284,7 @@ class J2StoreControllerCheckouts extends F0FController
 	function register_validate() {
         $platform = J2Store::platform();
 		$app = $platform->application();
-		$user = JFactory::getUser();
+        $user = $app->getIdentity();
 		$session = $app->getSession();
 		$view = $this->getThisView();
 		if ($model = $this->getThisModel())
@@ -409,8 +412,8 @@ class J2StoreControllerCheckouts extends F0FController
 	}
 
 	function guest() {
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
 		$cart_model = F0FModel::getTmpInstance('Carts', 'J2StoreModel');
 		$view = $this->getThisView();
 		if ($model = $this->getThisModel())
@@ -515,8 +518,8 @@ class J2StoreControllerCheckouts extends F0FController
 
 	function guest_validate() {
 
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
 		$address_model = F0FModel::getTmpInstance('Addresses', 'J2StoreModel');
 		$view = $this->getThisView();
 		if ($model = $this->getThisModel())
@@ -535,7 +538,7 @@ class J2StoreControllerCheckouts extends F0FController
 		$json = array();
 
 		// Validate if customer is logged in.
-		if (JFactory::getUser()->id) {
+		if ($app->getIdentity()->id) {
 			$json['redirect'] = $redirect_url;
 		}
 
@@ -670,8 +673,8 @@ class J2StoreControllerCheckouts extends F0FController
 
 	function guest_shipping() {
 
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
 		$view = $this->getThisView();
 		if ($model = $this->getThisModel())
 		{
@@ -729,8 +732,8 @@ class J2StoreControllerCheckouts extends F0FController
 	}
 
 	function guest_shipping_validate() {
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
 		$address_model = F0FModel::getTmpInstance('Addresses', 'J2StoreModel');
 		$params = J2Store::config();
 		$view = $this->getThisView();
@@ -748,7 +751,7 @@ class J2StoreControllerCheckouts extends F0FController
 		$json = array();
 
 		// Validate if customer is logged in.
-		if (JFactory::getUser()->id) {
+		if ($app->getIdentity()->id) {
 			$json['redirect'] = $redirect_url;
 		}
 
@@ -834,8 +837,8 @@ class J2StoreControllerCheckouts extends F0FController
 
 	function billing_address() {
 
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
 		$address_model = F0FModel::getTmpInstance('Addresses', 'J2StoreModel');
 		$view = $this->getThisView();
 		if ($model = $this->getThisModel())
@@ -843,7 +846,7 @@ class J2StoreControllerCheckouts extends F0FController
 			// Push the model into the view (as default)
 			$view->setModel($model, true);
 		}
-		$user = JFactory::getUser();
+		$user = $app->getIdentity();
 		$address = F0FTable::getAnInstance('Address', 'J2StoreTable');
 		if($user->id) {
 			//$address = $address_model->user_id($user->id)->getFirstItem();
@@ -939,9 +942,9 @@ class J2StoreControllerCheckouts extends F0FController
 
 	function billing_address_validate() {
 
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
-		$user = JFactory::getUser();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
+		$user = $app->getIdentity();
 		$address_model = F0FModel::getTmpInstance('Addresses', 'J2StoreModel');
 
 		$view = $this->getThisView();
@@ -1048,9 +1051,9 @@ class J2StoreControllerCheckouts extends F0FController
 
 	function shipping_address() {
 
-		$app = JFactory::getApplication();
-		$user = JFactory::getUser();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$user = $app->getIdentity();
+		$session = $app->getSession();
 		$address_model = F0FModel::getTmpInstance('Addresses', 'J2StoreModel');
 
 		$view = $this->getThisView();
@@ -1145,9 +1148,9 @@ class J2StoreControllerCheckouts extends F0FController
 
 	function shipping_address_validate() {
 
-		$app = JFactory::getApplication();
-		$user = JFactory::getUser();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$user = $app->getIdentity();
+		$session = $app->getSession();
 		$address_model = F0FModel::getTmpInstance('Addresses', 'J2StoreModel');
 		$params = J2Store::config();
 		$view = $this->getThisView();
@@ -1275,9 +1278,9 @@ class J2StoreControllerCheckouts extends F0FController
 	//shipping and payment method
 
 	function shipping_payment_method() {
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
-		$user = JFactory::getUser();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
+		$user = $app->getIdentity();
 		$params = J2Store::config();
 		$address_model = F0FModel::getTmpInstance('Addresses', 'J2StoreModel');
 
@@ -1395,9 +1398,9 @@ class J2StoreControllerCheckouts extends F0FController
 
 	function shipping_payment_method_validate() {
 
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
-		$user = JFactory::getUser();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
+		$user = $app->getIdentity();
 		$params = J2Store::config();
 		$address_model = F0FModel::getTmpInstance('Addresses', 'J2StoreModel');
 
@@ -1555,9 +1558,9 @@ class J2StoreControllerCheckouts extends F0FController
 	 * display expressconfirm layout
 	 *   */
 	function expressconfirm(){
-		$app = JFactory::getApplication();
+		$app = Factory::getApplication();
 		$data = $app->input->getArray($_REQUEST);
-		$session = JFactory::getSession();
+		$session = $app->getSession();
 		$view = $this->getThisView();
 		$order = '';
 		if ($model = $this->getThisModel())
@@ -1591,9 +1594,9 @@ class J2StoreControllerCheckouts extends F0FController
 		//no cache
 		J2Store::utilities()->nocache();
 
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
-		$user = JFactory::getUser();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
+		$user = $app->getIdentity();
 		$params = J2Store::config();
 		$address_model = F0FModel::getTmpInstance('Addresses', 'J2StoreModel');
 		JPluginHelper::importPlugin ('j2store');
@@ -1757,7 +1760,7 @@ class J2StoreControllerCheckouts extends F0FController
 			default :
 				$rates = F0FModel::getTmpInstance ( 'Shippings', 'J2StoreModel' )->getShippingRates ( $order );
 				$default_rate = array ();
-				$session = JFactory::getSession ();
+                $session = Factory::getApplication()->getSession();
 				$shipping_values = $session->get ( 'shipping_values', array (), 'j2store' );
 				if(count($rates)){
 					$order->show_payment_method = 1;
@@ -1791,11 +1794,11 @@ class J2StoreControllerCheckouts extends F0FController
 	}
 
 	function getPaymentForm($element = '', $plain_format = false) {
-		$app = JFactory::getApplication ();
+		$app = Factory::getApplication();
 		$values = $app->input->getArray ( $_REQUEST );
 		$html = '';
 		$text = "";
-		$user = JFactory::getUser ();
+		$user = $app->getIdentity();
 		if (empty ( $element )) {
 			$element = $app->input->getString ( 'payment_element' );
 		}
@@ -1833,7 +1836,7 @@ class J2StoreControllerCheckouts extends F0FController
 		$response ['msg'] = '';
 		$response ['error'] = '';
 
-		$app = JFactory::getApplication ();
+		$app = Factory::getApplication();
 		JPluginHelper::importPlugin ( 'j2store' );
 
 		// verify the form data
@@ -1905,9 +1908,9 @@ class J2StoreControllerCheckouts extends F0FController
 
 		J2Store::utilities()->nocache();
 
-		$app = JFactory::getApplication ();
-		$user = JFactory::getUser();
-		$session = JFactory::getSession();
+		$app = Factory::getApplication();
+		$user = $app->getIdentity();
+		$session = $app->getSession();
 		$params = J2Store::config();
 		$order_model = F0FModel::getTmpInstance('Orders', 'J2StoreModel');
 		$orderpayment_type = $app->input->getString ( 'orderpayment_type' );

--- a/components/com_j2store/controllers/products.php
+++ b/components/com_j2store/controllers/products.php
@@ -6,6 +6,7 @@
  */
 // No direct access to this file
 use Joomla\Registry\Format\Json;
+use Joomla\CMS\Factory;
 
 defined('_JEXEC') or die;
 require_once(JPATH_ADMINISTRATOR.'/components/com_j2store/controllers/productbase.php');
@@ -23,13 +24,13 @@ class J2StoreControllerProducts extends J2StoreControllerProductsBase
 
         $platform = J2Store::platform();
 		$app = $platform->application();
-		$session = JFactory::getSession();
-		$db = JFactory::getDbo();
+		$session = $app->getSession();
+        $db = Factory::getContainer()->get('DatabaseDriver');
 		$active	= $app->getMenu()->getActive();
 		$menus		= $app->getMenu();
 		$pathway	= $app->getPathway();
-		$document = JFactory::getDocument();
-		$lang = JFactory::getLanguage();
+		$document = $app->getDocument();
+		$lang = $app->getLanguage();
 
 		$manufacturer_ids = $this->input->get('manufacturer_ids', array(), 'ARRAY');
 		$vendor_ids = $this->input->get('vendor_ids', array(), 'ARRAY');
@@ -306,7 +307,7 @@ class J2StoreControllerProducts extends J2StoreControllerProductsBase
             $content ='var j2store_product_base_link = "";';
         }
         $platform->addInlineScript($content);
-		//JFactory::getDocument()->addScriptDeclaration($content);
+		//Factory::getDocument()->addScriptDeclaration($content);
         $view_html = '';
         J2Store::plugin()->event('ViewProductListHtml', array(&$view_html, &$view, $model));
 		//$this->display(in_array('browse', $this->cacheableTasks));
@@ -471,7 +472,7 @@ class J2StoreControllerProducts extends J2StoreControllerProductsBase
 	}
 
     public function getProductOptionList($product_type){
-        $db = JFactory::getDbo();
+        $db = Factory::getContainer()->get('DatabaseDriver');
         $query = $db->getQuery(true);
         $query->select('j2store_option_id, option_unique_name, option_name');
         $query->from('#__j2store_options');
@@ -559,7 +560,7 @@ class J2StoreControllerProducts extends J2StoreControllerProductsBase
 
 	public function view() {
 
-		$app = JFactory::getApplication();
+		$app = Factory::getApplication();
 		$product_id = $app->input->getInt('id');
 
 		if(!$product_id) {
@@ -591,7 +592,7 @@ class J2StoreControllerProducts extends J2StoreControllerProductsBase
 
 		//get product
 		$product = $product_helper->setId($product_id)->getProduct();
-        $user = JFactory::getUser();
+        $user = $app->getIdentity();
         //access
         $access_groups = $user->getAuthorisedViewLevels();
 		if(!isset($product->source->access) || empty($product->source->access) || !in_array($product->source->access,$access_groups) ){
@@ -663,7 +664,7 @@ class J2StoreControllerProducts extends J2StoreControllerProductsBase
 		$active	= $app->getMenu()->getActive();
 		$menus		= $app->getMenu();
 		$pathway	= $app->getPathway();
-		$document = JFactory::getDocument();
+		$document   = $app->getDocument();
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
 		$menu = $menus->getActive();

--- a/components/com_j2store/controllers/producttags.php
+++ b/components/com_j2store/controllers/producttags.php
@@ -8,6 +8,9 @@
 use Joomla\Registry\Format\Json;
 
 defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+
 require_once(JPATH_ADMINISTRATOR.'/components/com_j2store/controllers/productbase.php');
 class J2StoreControllerProducttags extends J2StoreControllerProductsBase
 {
@@ -21,14 +24,14 @@ class J2StoreControllerProducttags extends J2StoreControllerProductsBase
 		$utility->nocache();
 		$utility->clear_cache();
 
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
-		$db = JFactory::getDbo();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
+        $db = Factory::getContainer()->get('DatabaseDriver');
 		$active	= $app->getMenu()->getActive();
 		$menus		= $app->getMenu();
 		$pathway	= $app->getPathway();
-		$document = JFactory::getDocument();
-		$lang = JFactory::getLanguage();
+		$document = $app->getDocument();
+		$lang = $app->getLanguage();
 
 		$manufacturer_ids = $app->input->get('manufacturer_ids', array(), 'ARRAY');
 		$vendor_ids = $app->input->get('vendor_ids', array(), 'ARRAY');
@@ -281,7 +284,7 @@ class J2StoreControllerProducttags extends J2StoreControllerProductsBase
 
 		$view->assign('active_menu', $menu) ;
 		$content ='var j2store_product_base_link ="'. $menu->link.'&Itemid='.$menu->id .'";';
-		JFactory::getDocument()->addScriptDeclaration($content);
+        $document->addScriptDeclaration($content);
 
         $view_html = '';
         J2Store::plugin()->event('ViewProductListTagHtml', array(&$view_html, &$view, $model));
@@ -291,7 +294,7 @@ class J2StoreControllerProducttags extends J2StoreControllerProductsBase
 	}
 
 	public function getTagId($tag_alias){
-		$db = JFactory::getDbo ();
+        $db = Factory::getContainer()->get('DatabaseDriver');
 		$query = $db->getQuery (true);
 		$query->select ( 'id' )->from ( '#__tags' )->where ( 'alias ='.$db->q($tag_alias) );
 		$db->setQuery ( $query );
@@ -393,7 +396,7 @@ class J2StoreControllerProducttags extends J2StoreControllerProductsBase
 
 	public function view() {
 
-		$app = JFactory::getApplication();
+		$app = Factory::getApplication();
 		$product_id = $app->input->getInt('id');
 
 		if(!$product_id) {
@@ -423,7 +426,7 @@ class J2StoreControllerProducttags extends J2StoreControllerProductsBase
 
 		//get product
 		$product = $product_helper->setId($product_id)->getProduct();
-        $user = JFactory::getUser();
+        $user = $app->getIdentity();
         //access
         $access_groups = $user->getAuthorisedViewLevels();
         if(!isset($product->source->access) || empty($product->source->access) || !in_array($product->source->access,$access_groups) ){
@@ -494,7 +497,7 @@ class J2StoreControllerProducttags extends J2StoreControllerProductsBase
 		$active	= $app->getMenu()->getActive();
 		$menus		= $app->getMenu();
 		$pathway	= $app->getPathway();
-		$document = JFactory::getDocument();
+		$document   = $app->getDocument();
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
 		$menu = $menus->getActive();
@@ -596,7 +599,7 @@ class J2StoreControllerProducttags extends J2StoreControllerProductsBase
         if(isset($product->main_tag) && !empty($product->main_tag)){
 
             $tag_menus =JMenu::getInstance('site');
-            $lang = JFactory::getLanguage();
+            $lang = $app->getLanguage();
 
 
             $tag_menu_id = '';
@@ -637,7 +640,7 @@ class J2StoreControllerProducttags extends J2StoreControllerProductsBase
                     }
                 }
                 // 3. set product canonical url
-                $doc = JFactory::getDocument();
+                $doc = $app->getDocument();
                 $canonical = trim(JUri::root(),'/').'/'.ltrim(J2Store::platform()->getProductUrl(array('task' => 'view','id' => $product->j2store_product_id,'Itemid' => $tag_menu_id),true),'/');
                 $doc->addHeadLink(htmlspecialchars($canonical), 'canonical');
             }

--- a/components/com_j2store/models/callback.php
+++ b/components/com_j2store/models/callback.php
@@ -11,11 +11,13 @@
 
 defined ( '_JEXEC' ) or die ( 'Restricted access' );
 
+use Joomla\CMS\Factory;
+
 class J2StoreModelCallback extends F0FModel {
 
 	function runCallback($method) {
 
-		$app = JFactory::getApplication ();
+		$app = Factory::getApplication ();
 		$rawDataPost = $app->input->getArray($_POST);
 		$rawDataGet = $app->input->getArray($_GET);
 		$data = array_merge ( $rawDataGet, $rawDataPost );

--- a/components/com_j2store/models/vendors.php
+++ b/components/com_j2store/models/vendors.php
@@ -6,11 +6,14 @@
  */
 // No direct access to this file
 defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+
 class J2StoreModelVendors extends F0FModel {
 
 	public function &getItem($id = null)
 	{
-		$user = JFactory::getUser();
+        $user = Factory::getApplication()->getIdentity();
 		$this->record = F0FTable::getAnInstance('Vendoruser','J2StoreTable');
 		$this->record->load($user->id);
 
@@ -23,7 +26,7 @@ class J2StoreModelVendors extends F0FModel {
 	
 	public function buildQuery($overrideLimits = false)
 	{
-		$db = JFactory::getDbo();
+        $db = Factory::getContainer()->get('DatabaseDriver');
 		$query  = $db->getQuery(true);
 		$query->select('#__j2store_vendors.*')->from("#__j2store_vendors as #__j2store_vendors");
 		$query->select($db->qn('#__j2store_addresses').'.j2store_address_id')
@@ -54,13 +57,13 @@ class J2StoreModelVendors extends F0FModel {
 
 	public function buildOrderbyQuery(&$query){
 		$state = $this->getState();
-		$app = JFactory::getApplication();
+		$app = Factory::getApplication();
 		$filter_order_Dir = $app->input->getString('filter_order_Dir','asc');
 		$filter_order = $app->input->getString('filter_order','filter_name');
         if(!in_array(strtolower($filter_order_Dir),array('asc','desc'))){
             $filter_order_Dir = 'desc';
         }
-        $db = JFactory::getDbo();
+        $db = Factory::getContainer()->get('DatabaseDriver');
 		//check filter
 		if($filter_order =='j2store_vendor_id' || $filter_order =='enabled' ){
 			$query->order('#__j2store_vendors.'.$filter_order.' '.$filter_order_Dir);

--- a/components/com_j2store/router.php
+++ b/components/com_j2store/router.php
@@ -7,6 +7,8 @@
 // No direct access to this file
 defined ( '_JEXEC' ) or die ();
 
+use Joomla\CMS\Factory;
+
 // Load FOF
 // Include F0F
 if(!defined('F0F_INCLUDED')) {
@@ -47,7 +49,7 @@ class J2StoreRouter extends JComponentRouterBase {
 		$j2storesource = J2StoreRouterHelper::getAndPop ( $query, 'j2storesource' );
         $lang = J2StoreRouterHelper::getAndPop ( $query, 'lang' );
         if(empty($lang)){
-            $langu = JFactory::getLanguage();
+            $langu = Factory::getApplication()->getLanguage();
             $lang = $langu->getTag();
         }
 		// $orderpayment_type = J2StoreRouterHelper::getAndPop($query, 'orderpayment_type');

--- a/components/com_j2store/views/carts/tmpl/default.php
+++ b/components/com_j2store/views/carts/tmpl/default.php
@@ -4,13 +4,16 @@
  * @copyright Copyright (c)2014-17 Ramesh Elamathi / J2Store.org
  * @license GNU GPL v3 or later
  */
+
+use Joomla\CMS\Factory;
+
 // No direct access to this file
 defined('_JEXEC') or die;
 $platform = J2Store::platform();
 // get j2Store Params to determine which bootstrap version we're using - Waseem Sadiq (waseem@bulletprooftemplates.com)
 $J2gridRow = ($this->params->get('bootstrap_version', 2) == 2) ? 'row-fluid' : 'row';
 $J2gridCol = ($this->params->get('bootstrap_version', 2) == 2) ? 'span' : 'col-md-';
-$app = JFactory::getApplication();
+$app = Factory::getApplication();
 $active_menu = $app->getMenu()->getActive();
 $page_heading = is_object($active_menu) ? $active_menu->getParams(): $platform->getRegistry('{}');
 $page_heading_enabled = $page_heading->get('show_page_heading',0);

--- a/components/com_j2store/views/checkout/tmpl/default.php
+++ b/components/com_j2store/views/checkout/tmpl/default.php
@@ -14,10 +14,13 @@
 
 // no direct access
 defined( '_JEXEC' ) or die( 'Restricted access' );
+
+use Joomla\CMS\Factory;
+
 $platform = J2Store::platform();
 $action = $platform->getCheckoutUrl();
 $ajax_base_url = JRoute::_('index.php');
-$app = JFactory::getApplication();
+$app = Factory::getApplication();
 $active_menu = $app->getMenu()->getActive();
 
 $page_heading = (isset($active_menu->params) && is_object($active_menu->params)) ? $active_menu->getParams(): $platform->getRegistry('{}');

--- a/components/com_j2store/views/checkout/tmpl/default_billing.php
+++ b/components/com_j2store/views/checkout/tmpl/default_billing.php
@@ -11,6 +11,9 @@
 
 // no direct access
 defined( '_JEXEC' ) or die( 'Restricted access' );
+
+use Joomla\CMS\Factory;
+
 // get j2Store Params to determine which bootstrap version we're using - Waseem Sadiq (waseem@bulletprooftemplates.com)
 $J2gridRow = ($this->params->get('bootstrap_version', 2) == 2) ? 'row-fluid' : 'row';
 $J2gridCol = ($this->params->get('bootstrap_version', 2) == 2) ? 'span' : 'col-md-';
@@ -133,7 +136,7 @@ if (isset($this->addresses) && count($this->addresses) > 0) : ?>
 		<input type="button" value="<?php echo JText::_('J2STORE_CHECKOUT_CONTINUE'); ?>" id="button-billing-address" class="button btn btn-primary" />
 	</div>
 </div>
-<input type="hidden" name="email" value="<?php echo JFactory::getUser()->email; ?>" />
+<input type="hidden" name="email" value="<?php echo Factory::getApplication()->getIdentity()->email; ?>" />
 <input type="hidden" name="task" value="billing_address_validate" />
 <input type="hidden" name="option" value="com_j2store" />
 <input type="hidden" name="view" value="checkout" />

--- a/components/com_j2store/views/checkout/tmpl/postpayment.php
+++ b/components/com_j2store/views/checkout/tmpl/postpayment.php
@@ -11,13 +11,16 @@
 
 // no direct access
 defined('_JEXEC') or die('Restricted access');
+
+use Joomla\CMS\Factory;
+
 // get j2Store Params to determine which bootstrap version we're using - Waseem Sadiq (waseem@bulletprooftemplates.com)
 $J2gridRow = ($this->params->get('bootstrap_version', 2) == 2) ? 'row-fluid' : 'row';
 $J2gridCol = ($this->params->get('bootstrap_version', 2) == 2) ? 'span' : 'col-md-';
 
 $order_link = @$this->order_link;
 $plugin_html = @$this->plugin_html;
-$app = JFactory::getApplication();
+$app = Factory::getApplication();
 $paction = $app->input->getString('paction');
 $after_post_html = J2Store::plugin ()->eventWithHtml ( 'AfterPostPayment', array($this) );
 ?>

--- a/components/com_j2store/views/checkout/view.html.php
+++ b/components/com_j2store/views/checkout/view.html.php
@@ -7,15 +7,18 @@
 
 // No direct access
 defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+
 class J2StoreViewCheckout extends F0FViewHtml
 {
 
 	protected function onDisplay($tpl = null)
 	{
 	
-		$app = JFactory::getApplication();
-		$session = JFactory::getSession();
-		$user = JFactory::getUser();
+		$app = Factory::getApplication();
+		$session = $app->getSession();
+		$user = $app->getIdentity();
 		$view = $this->input->getCmd('view', 'checkout');
 		
 		$this->params = J2Store::config();

--- a/components/com_j2store/views/myprofile/tmpl/address.php
+++ b/components/com_j2store/views/myprofile/tmpl/address.php
@@ -18,7 +18,7 @@ if(empty($this->address->type)){
 }
 $app = J2Store::platform();
 $back_url = $app->getMyprofileUrl();
-$user = JFactory::getUser();
+$user = Factory::getApplication()->getIdentity();
 if(empty($user->id)){
 	$app->redirect($back_url);
 }

--- a/components/com_j2store/views/myprofile/tmpl/default.php
+++ b/components/com_j2store/views/myprofile/tmpl/default.php
@@ -6,6 +6,9 @@
 */
 // No direct access to this file
 defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+
 $platform = J2Store::platform();
 $platform->loadExtra('behavior.modal');
 $this->params = J2Store::config();
@@ -34,7 +37,7 @@ $page_heading_text = $page_heading->get('page_heading','');
     $return_url = $platform->getMyprofileUrl(array(),false,true);
 	$return = base64_encode($return_url);
 	?>
-	<?php $user = JFactory::getUser (); ?>
+	<?php $user = Factory::getApplication()->getIdentity(); ?>
 	<?php if($user->id > 0): ?>
 	<div class="pull-right">
 		<form action="<?php echo JRoute::_('index.php'); ?>" method="post" id="login-form" class="form-vertical">

--- a/components/com_j2store/views/myprofile/tmpl/default_login.php
+++ b/components/com_j2store/views/myprofile/tmpl/default_login.php
@@ -11,6 +11,9 @@
 
 // no direct access
 defined('_JEXEC') or die('Restricted access');
+
+use Joomla\CMS\Factory;
+
 $platform = J2Store::platform();
 $return_url = $platform->getMyprofileUrl(array(),false,true);
 //$return_url = trim(JUri::root(),'/').$platform->getMyprofileUrl();
@@ -21,7 +24,7 @@ $return_url = $platform->getMyprofileUrl(array(),false,true);
 $guest_action_url = $platform->getMyprofileUrl(array('task' => 'guestentry'));
 //JRoute::_( "index.php?option=com_j2store&view=myprofile&task=guestentry" );
 $platform->addScript('j2store-jquery-validate','/media/j2store/js/jquery.validate.min.js');
-//$document =JFactory::getDocument();
+//$document = Factory::getApplication()->getDocument();
 //$document->addScript(JURI::root(true).'/media/j2store/js/jquery.validate.min.js');
 $params = J2Store::config();
 // get j2Store Params to determine which bootstrap version we're using - Waseem Sadiq (waseem@bulletprooftemplates.com)
@@ -63,7 +66,7 @@ $J2gridCol = ($params->get('bootstrap_version', 2) == 2) ? 'span' : 'col-md-';
 					' JLanguage.LOGIN_WITH_OPENID = \''.JText::_( 'LOGIN_WITH_OPENID' ).'\';'.
 					' JLanguage.NORMAL_LOGIN = \''.JText::_( 'NORMAL_LOGIN' ).'\';'.
 					' var modlogin = 1;';
-//			$document = JFactory::getDocument();
+//			$document = Factory::getApplication()->getDocument();
 //			$document->addScriptDeclaration( $langScript );
 			$platform->addInlineScript($langScript);
 

--- a/components/com_j2store/views/myprofile/tmpl/default_orders.php
+++ b/components/com_j2store/views/myprofile/tmpl/default_orders.php
@@ -6,8 +6,11 @@
  */
 // No direct access to this file
 defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+
 $currency = J2Store::currency();
-$doc = JFactory::getDocument();
+$doc = Factory::getApplication()->getDocument();
 J2Store::strapper()->addFontAwesome();
 ?>
 

--- a/components/com_j2store/views/myprofile/tmpl/orderitems.php
+++ b/components/com_j2store/views/myprofile/tmpl/orderitems.php
@@ -7,6 +7,9 @@
  */
 // No direct access to this file
 defined ( '_JEXEC' ) or die ();
+
+use Joomla\CMS\Factory;
+
 $order = $this->order;
 $platform = J2Store::platform();
 $items = $this->order->getItems();
@@ -14,10 +17,10 @@ $currency = J2Store::currency();
 $this->taxes = $order->getOrderTaxrates();
 $colspan = '2';
 if(empty($order->customer_language) || $order->customer_language == '*' || $order->customer_language == ''){
-    $language = JFactory::getLanguage();
+    $language = Factory::getApplication()->getLanguage();
 
 }else{
-    $conf = JFactory::getConfig();
+    $conf = Factory::getContainer()->get('config');
     $debug = $conf->get('debug_lang');
     $language = JLanguage::getInstance($order->customer_language, $debug);
     $language->load('com_j2store');

--- a/components/com_j2store/views/myprofile/tmpl/view.php
+++ b/components/com_j2store/views/myprofile/tmpl/view.php
@@ -9,10 +9,12 @@
 # Technical Support:  Forum - http://j2store.org/forum/index.html
 -------------------------------------------------------------------------*/
 
-
 //no direct access
 defined('_JEXEC') or die('Restricted access');
-$task = JFactory::getApplication()->input->getString('task');
+
+use Joomla\CMS\Factory;
+
+$task = Factory::getApplication()->input->getString('task');
 ?>
 <?php if ($task == 'printOrder') : ?>
     <style type="text/css" media="print">

--- a/components/com_j2store/views/product/tmpl/adminitem_cart.php
+++ b/components/com_j2store/views/product/tmpl/adminitem_cart.php
@@ -7,7 +7,10 @@
 
 // No direct access
 defined('_JEXEC') or die;
-$app = JFactory::getApplication();
+
+use Joomla\CMS\Factory;
+
+$app = Factory::getApplication();
 if(!empty($this->product->addtocart_text)) {
 	$cart_text = JText::_($this->product->addtocart_text);
 } else {

--- a/components/com_j2store/views/product/tmpl/item_cart.php
+++ b/components/com_j2store/views/product/tmpl/item_cart.php
@@ -7,7 +7,10 @@
 
 // No direct access
 defined('_JEXEC') or die;
-$app = JFactory::getApplication();
+
+use Joomla\CMS\Factory;
+
+$app = Factory::getApplication();
 if(!empty($this->product->addtocart_text)) {
 	$cart_text = JText::_($this->product->addtocart_text);
 } else {

--- a/components/com_j2store/views/product/view.html.php
+++ b/components/com_j2store/views/product/view.html.php
@@ -8,11 +8,13 @@
 // No direct access
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+
 class J2StoreViewProduct extends F0FViewHtml
 {	
 	
 	protected function onRead($tpl = null) {
-		JFactory::getLanguage ()->load ('com_j2store', JPATH_ADMINISTRATOR);
+		Factory::getLanguage ()->load ('com_j2store', JPATH_ADMINISTRATOR);
 		/* JRequest::setVar('hidemainmenu', true);
 		$model = $this->getModel('Products');
 		$product_id = $this->input->getInt('id', 0);

--- a/components/com_j2store/views/products/view.feed.php
+++ b/components/com_j2store/views/products/view.feed.php
@@ -6,6 +6,8 @@
  */
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+
 /**
  * Frontpage View class
  *
@@ -47,7 +49,7 @@ class J2StoreViewProducts extends JViewLegacy
 			$link = $platform->getProductUrl(array('task' => 'view', 'id' => $row->j2store_product_id));
 			// Get row fulltext
 			$description = ($params->get('feed_summary', 0) ? $row->product_short_desc . $row->product_long_desc : $row->product_short_desc);
-			$user = JFactory::getUser($row->created_by);
+            $user = Factory::getApplication()->getIdentity($row->created_by);
 			$author      = $user->name;
 
 			// Load individual item creator class

--- a/components/com_j2store/views/products/view.html.php
+++ b/components/com_j2store/views/products/view.html.php
@@ -6,6 +6,9 @@
  */
 // No direct access to this file
 defined('_JEXEC') or die('Restricted access');
+
+use Joomla\CMS\Factory;
+
 class J2StoreViewProducts extends F0FViewHtml
 {
 	/**
@@ -24,7 +27,7 @@ class J2StoreViewProducts extends F0FViewHtml
 	 */
 
 	protected function onDisplay($tpl= null) {
-		JFactory::getLanguage ()->load ('com_j2store', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load ('com_j2store', JPATH_ADMINISTRATOR);
 		$view = $this->input->getCmd('view', 'cpanel');
 		
 		if (in_array($view, array('cpanel', 'cpanels')))
@@ -46,7 +49,7 @@ class J2StoreViewProducts extends F0FViewHtml
 		// Pass page params on frontend only
 		if (F0FPlatform::getInstance()->isFrontend())
 		{
-		//	$params = JFactory::getApplication()->getParams();
+		//	$params = Factory::getApplication()->getParams();
 		//	$this->params = $params;
 		}
 		

--- a/components/com_j2store/views/producttags/view.feed.php
+++ b/components/com_j2store/views/producttags/view.feed.php
@@ -6,6 +6,8 @@
  */
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+
 /**
  * Frontpage View class
  *
@@ -47,7 +49,7 @@ class J2StoreViewProducttags extends JViewLegacy
 			$link = $platform->getProductUrl(array('task' => 'view','id' => $row->j2store_product_id),true);
 			// Get row fulltext
 			$description = ($params->get('feed_summary', 0) ? $row->product_short_desc . $row->product_long_desc : $row->product_short_desc);
-			$user = JFactory::getUser($row->created_by);
+            $user = Factory::getApplication()->getIdentity($row->created_by);
 			$author      = $user->name;
 
 			// Load individual item creator class

--- a/components/com_j2store/views/producttags/view.html.php
+++ b/components/com_j2store/views/producttags/view.html.php
@@ -4,6 +4,9 @@
  * @copyright Copyright (c)2014-17 Ramesh Elamathi / J2Store.org
  * @license GNU GPL v3 or later
  */
+
+use Joomla\CMS\Factory;
+
 // No direct access to this file
 defined('_JEXEC') or die('Restricted access');
 class J2StoreViewProducttags extends F0FViewHtml
@@ -24,7 +27,7 @@ class J2StoreViewProducttags extends F0FViewHtml
 	 */
 
 	protected function onDisplay($tpl= null) {
-		JFactory::getLanguage ()->load ('com_j2store', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage ()->load ('com_j2store', JPATH_ADMINISTRATOR);
 		$view = $this->input->getCmd('view', 'cpanel');
 		
 		if (in_array($view, array('cpanel', 'cpanels')))
@@ -46,7 +49,7 @@ class J2StoreViewProducttags extends F0FViewHtml
 		// Pass page params on frontend only
 		if (F0FPlatform::getInstance()->isFrontend())
 		{
-		//	$params = JFactory::getApplication()->getParams();
+		//	$params = Factory::getApplication()->getParams();
 		//	$this->params = $params;
 		}
 		

--- a/components/com_j2store/views/vendor/view.html.php
+++ b/components/com_j2store/views/vendor/view.html.php
@@ -7,10 +7,12 @@
 // No direct access to this file
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+
 class J2StoreViewVendors extends F0FViewHtml {
 	 protected function onAdd($tpl=null){
-		$app = JFactory::getApplication();
-		$user = JFactory::getUser();
+		$app = Factory::getApplication();
+		$user = Factory::getUser();
 		$model = $this->getModel('Vendors');
 		$this->item = $model->getItem();
 


### PR DESCRIPTION
The JFactory class has been deprecated for Joomla 5.
Update the code to replace JFactory with Factory, and update some calls to Factory::getDbo as well.
The extension is more compatible with Joomla 5 and minimizes deprecated function calls.
