### PR TITLE
Translate the module title in addModuleToPosition()

### DIFF
--- a/script.j2store.php
+++ b/script.j2store.php
@@ -252,6 +252,9 @@ class Com_J2storeInstallerScript extends F0FUtilsInstallscript
             'position'   => $position,
         ];
 
+        // Load the module's language file
+        Factory::getLanguage()->load($module_name, JPATH_ADMINISTRATOR);
+
         $module['title']  = Text::_(strtoupper($module_name));
         $module['access'] = (int) Factory::getApplication()->get('access', 1);
         $module['params'] = array_merge([


### PR DESCRIPTION
The modules that are automatically installed on the admin side need to have their title translated.