### PR TITLE
Manage original error reporting level in preflight/postflight

### DIFF
--- a/script.j2store.php
+++ b/script.j2store.php
@@ -74,6 +74,13 @@ class Com_J2storeInstallerScript extends F0FUtilsInstallscript
   protected $minimumJoomlaVersion = '4.0.0';
   protected $maximumJoomlaVersion = '5.99.99';
 
+  /**
+  * Store original error reporting level
+  *
+  * @var int
+  */
+  protected $originalErrorReporting;
+
   protected $removeFilesAllVersions = array(
     'files' => array(
       // Use pathnames relative to your site's root, e.g.
@@ -166,6 +173,12 @@ class Com_J2storeInstallerScript extends F0FUtilsInstallscript
   public function postflight($type, $parent)
   {
       parent::postflight($type, $parent);
+
+      // Restore original error reporting level
+      if (isset($this->originalErrorReporting)) {
+          error_reporting($this->originalErrorReporting);
+          ini_set('display_errors', $this->originalErrorReporting > 0 ? 1 : 0);
+      }
 
       // Remove extra column from the variants table
 
@@ -331,6 +344,11 @@ class Com_J2storeInstallerScript extends F0FUtilsInstallscript
 
   public function preflight($type, $parent)
   {
+    // Store current error reporting level and set to exclude warnings/deprecations
+    $this->originalErrorReporting = error_reporting();
+    error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_WARNING & ~E_NOTICE);
+    ini_set('display_errors', 1);
+
     if (parent::preflight($type, $parent)) {
       $app = Factory::getApplication();
       $db = Factory::getDbo();


### PR DESCRIPTION
Added functionality to store and restore the original error reporting level during preflight and postflight operations. This prevents errors due to f0f deprecations.