### PR TITLE
s/ aggrement / agreement

### DIFF
--- a/plugins/j2store/payment_paypal/languages/en-GB.plg_j2store_payment_paypal.ini
+++ b/plugins/j2store/payment_paypal/languages/en-GB.plg_j2store_payment_paypal.ini
@@ -90,7 +90,7 @@ J2STORE_PAYMENT_PAYPALSUBSCRIPTION_FAILED_TOCREATE_TOKEN="Failed to create token
 J2STORE_PAYMENT_PAYPALSUBSCRIPTION_ORDER_DESCRIPTION="Order Description"
 J2STORE_PAYPAL_CUSTOM_NOTE="Learn how to get your API credentials from your PayPal account from the following url <a target='_blank' href='https://developer.paypal.com/docs/classic/api/apiCredentials/#create-an-api-signature'>https://developer.paypal.com/docs/classic/api/apiCredentials/#create-an-api-signature</a>"
 J2STORE_PAYPAL_SHOW_BILLING_AGREEMENT_TEXT_LABEL="Show billing agreement"
-J2STORE_PAYPAL_SHOW_BILLING_AGREEMENT_TEXT_LABEL_DESC="Displays custom billing aggrement text for subscription products"
+J2STORE_PAYPAL_SHOW_BILLING_AGREEMENT_TEXT_LABEL_DESC="Displays custom billing agreement text for subscription products"
 J2STORE_PAYPAL_NOTIFY_URL_TYPE="Choose the Callback URL to be used for IPN notifications"
 J2STORE_PAYPAL_NOTIFY_URL_TYPE_DESC="The default should be the Query string based url. If this does not work, you can try the secondary callback url. In a few cases, PayPal IPN servers might not be able to post back to urls with query strings. In those cases you can use either alternative 1 or alternative 2"
 J2STORE_PAYPAL_ALTERNATIVE_URL="Alternative 2:  Url without a query string (http(s)://www.example.com/plugins/j2store/payment_paypal/payment_paypal/tmpl/notify.php)"


### PR DESCRIPTION
This is just in the language value so is fully b/c

Doesnt fix similar errors in the rest of the plugin show_billing_aggrement_text
billing_aggrement_text